### PR TITLE
feat: analytical integrate() for BernsteinPolynomial via betainc

### DIFF
--- a/src/paramore/distributions.py
+++ b/src/paramore/distributions.py
@@ -158,6 +158,27 @@ class BernsteinPolynomial(BasePDF):
         )
         return jnp.dot(basis, self.coefs)
 
+    def integrate(self, lower=None, upper=None) -> Float[Array, ""]:
+        """Analytically integrate the Bernstein polynomial over [lower, upper].
+
+        Uses the identity B_{k,n}(t) = Beta_pdf(t; k+1, n-k+1) / (n+1), giving:
+            ∫_a^b Σ_k c_k B_{k,n}(t) dt
+                = (upper - lower) · Σ_k c_k [betainc(k+1, n-k+1, t_hi) - betainc(k+1, n-k+1, t_lo)] / (n+1)
+        where t_lo, t_hi are the normalized bounds in [0, 1].
+        """
+        lower = self.lower if lower is None else lower
+        upper = self.upper if upper is None else upper
+        n = self.degree
+        t_lo = (lower - self.lower) / (self.upper - self.lower)
+        t_hi = (upper - self.lower) / (self.upper - self.lower)
+        k = jnp.arange(n + 1)
+        a = k + 1.0
+        b = n - k + 1.0
+        cdf_hi = jax.scipy.special.betainc(a, b, t_hi)
+        cdf_lo = jax.scipy.special.betainc(a, b, t_lo)
+        integrals = (cdf_hi - cdf_lo) / (n + 1.0)
+        return jnp.dot(self.coefs, integrals) * (self.upper - self.lower)
+
     def sample(self, key, n_events: int) -> Float[Array, "n_events"]:
         return NotImplementedError(
             "Sampling from BernsteinPolynomial is not implemented yet"


### PR DESCRIPTION
## Summary

- Override `BasePDF.integrate()` in `BernsteinPolynomial` with a closed-form expression using `jax.scipy.special.betainc`
- Exploits the identity `B_{k,n}(t) = Beta_pdf(t; k+1, n-k+1) / (n+1)` to replace numerical quadrature (`quadgk`) with an analytical formula
- Significant speedup in complex workspaces; example below gives me 8x speedup in evaluation. 

## Benchmark

```python
"""Benchmark: BernsteinPolynomial.integrate analytical vs quadgk."""
from __future__ import annotations

import time

import jax
import jax.numpy as jnp
import paramore as pm
from paramore.distributions import BasePDF

jax.config.update("jax_enable_x64", True)

# -- Setup: degree-4 Bernstein polynomial on [100, 180] --
coefs = jnp.array([1.0, 0.223, 0.0098, 0.2437, 1.2e-7])
bpoly = pm.BernsteinPolynomial(coefs=coefs, lower=100.0, upper=180.0)

bin_lo = jnp.linspace(100.0, 179.0, 80)
bin_hi = bin_lo + 1.0

def bench(fn, n=200):
    fn()  # warmup
    times = []
    for _ in range(n):
        t0 = time.perf_counter()
        result = fn()
        jax.block_until_ready(result)
        times.append(time.perf_counter() - t0)
    return result, sum(times) / len(times)

# -- Baseline: quadgk (via base class) --
@jax.jit
def integrate_quadgk(lo, hi):
    return jax.vmap(lambda a, b: BasePDF.integrate(bpoly, a, b))(lo, hi)

result_quadgk, avg_quadgk = bench(lambda: integrate_quadgk(bin_lo, bin_hi))

# -- Analytical: betainc (via new override) --
@jax.jit
def integrate_analytical(lo, hi):
    return jax.vmap(lambda a, b: bpoly.integrate(a, b))(lo, hi)

result_analytical, avg_analytical = bench(lambda: integrate_analytical(bin_lo, bin_hi))

# -- Results --
max_diff = float(jnp.max(jnp.abs(result_quadgk - result_analytical)))
print(f"quadgk:     {avg_quadgk*1e3:.2f} ms")
print(f"analytical: {avg_analytical*1e3:.2f} ms")
print(f"max diff:   {max_diff:.2e}")
assert max_diff < 1e-10, f"Results diverge: max diff = {max_diff}"
```